### PR TITLE
Append '/' to endpoint when absent

### DIFF
--- a/agent/agent-bootstrap.py
+++ b/agent/agent-bootstrap.py
@@ -18,6 +18,10 @@ parser.add_argument('-v',dest='verbose',action='count',help='Verbose Level: Repe
 
 args = parser.parse_args()
 
+# Append '/' to endpoint URL if not already present
+if args.endpoint[-1] != '/':
+    args.endpoint += '/'
+
 def loggingLevelFromVerboseCount(vcount):
     if vcount is None:
         return logging.ERROR

--- a/server/templates/device.html
+++ b/server/templates/device.html
@@ -9,7 +9,7 @@
       <dt>First Seen</dt>
       <dd>{{ device['first_seen'] }}</dd>
     
-      <dt>Last Seend</dt>
+      <dt>Last Seen</dt>
       <dd>{{ device['last_updated'] }}</dd>
     </dl>
     <h2>Network Interfaces</h2>


### PR DESCRIPTION
Previously agent bootstrap would pass endpoint URL without trailing '/' if user didn't specify it